### PR TITLE
Add Helm CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,16 @@
 name: python-deployment
 
-run-name: ${{ github.actor }} - ${{ github.ref_name}} -${{ github.sha }}
+run-name: ${{ github.actor }} - ${{ github.ref_name }} - ${{ github.sha }}
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "your_name"]
   pull_request:
     branches: ["main"]
 
 env:
   PythonVersion: 3.8
-  DockerImageName: todoapp
+  ARTIFACT_NAME: repo-checkout
 
 jobs:
   python-ci:
@@ -21,6 +21,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        id: checkout_repo
+
+      - name: Upload Repository as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: .
 
       - name: Set up Python ${{ env.PythonVersion }}
         uses: actions/setup-python@v4
@@ -51,32 +58,69 @@ jobs:
           flake8 . --exit-zero --max-complexity=6
 
       - name: Upload python artifacts
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: python-artifacts
           path: .
 
   docker-ci:
-    runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'main' }}
     needs: python-ci
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/your_name'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./src
     steps:
+      - name: Download Repository Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: .
 
-    - uses: actions/download-artifact@v4
-      name: Download python artifacts
-      with:
-        name: python-artifacts
-        path: .
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src
+          push: true
+          tags: leoleiden/devops_cicd_repo:${{ github.sha }}
 
-    - name: Build and push
-      uses: docker/build-push-action@v5
-      with:
-        push: true
-        context: ./src
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.DockerImageName }}:${{ github.sha }}
+  helm-ci:
+    needs: docker-ci
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/your_name'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Repository Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: .
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+
+      - name: Helm Lint
+        run: |
+          helm lint helm-charts/todoapp/
+
+      - name: Helm Template
+        run: |
+          helm template todoapp helm-charts/todoapp/ > todoapp.yaml
+
+      - name: Package Helm chart
+        run: |
+          helm package helm-charts/todoapp/
+
+      - name: Upload Helm chart package
+        uses: actions/upload-artifact@v4
+        with:
+          name: todoapp-chart
+          path: todoapp-*.tgz


### PR DESCRIPTION
Feat: Додано завдання Helm CI до робочого процесу GitHub Actions

Це оновлення додає нове завдання `helm-ci` до робочого процесу GitHub Actions.
Завдання `helm-ci` виконує наступні кроки, використовуючи Helm чарт з `helm-charts/todoapp/`:
- Перевіряє Helm чарт на наявність помилок (`helm lint`).
- Генерує Kubernetes маніфести з чарту (`helm template`).
- Упаковує Helm чарт у файл `.tgz` (`helm package`).
- Завантажує упакований чарт як артефакт GitHub.

Репозиторій тепер вивантажується як артефакт в `python-ci` і завантажується в `docker-ci` та `helm-ci`, щоб забезпечити єдиний `checkout` на workflow run.

Посилання на успішний запуск Helm CI: https://github.com/leoleiden/devops_todolist_cicd_task_4_helm_ci/actions/runs/16532289687
